### PR TITLE
Django 1.7 support

### DIFF
--- a/django_database_constraints/forms.py
+++ b/django_database_constraints/forms.py
@@ -21,16 +21,9 @@ def validationerror_from_integrityerror(ierror, convertors=None):
             return v
 
 
-# FIXME: in Django 1.7 something like this is available
-# as part of the core API.
+# Kept indirected in case anyone was using this directly.
 def add_error_to_form(form, error, field=None):
-    if field is None: #pragma no cover
-        # because it's not called the way we do things right now
-        # and Django should get an official API for this at some point
-        field = forms.forms.NON_FIELD_ERRORS
-    if field not in form._errors:
-        form._errors[field] = form.error_class()
-    form._errors[field].append(error)
+    form.add_error(field, error)
 
 
 def transactional_save(form, convertors=None, tx_context_manager=None):

--- a/runtests.py
+++ b/runtests.py
@@ -1,9 +1,10 @@
 import os.path
 import subprocess
 import sys
+import django
 from django.conf import settings
 
-DATABASES = {
+_DATABASES = {
     'postgresql': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'NAME': 'django_database_constraints',
@@ -28,42 +29,34 @@ DATABASES = {
     #},
 }
 
-settings.configure(
-    DEBUG=True,
-    INSTALLED_APPS = [
-        'django_database_constraints',
-    ],
-    DATABASES = {
-        'default': DATABASES['postgresql'],
-    },
-)
-
-
-# after we have some settings
-from django.test.utils import override_settings
-
 
 def run_against(db):
-    @override_settings(DATABASES = { 'default': DATABASES[db] })
-    def run_tests():
-        print "Running tests against %s database." % db
+    print "Running tests against %s database." % db
 
-        #from django.test.simple import DjangoTestSuiteRunner
-        #test_runner = DjangoTestSuiteRunner(verbosity=1, failfast=False)
-        from django.test.runner import DiscoverRunner
-        test_runner = DiscoverRunner(verbosity=1, failfast=False)
-        failures = test_runner.run_tests(['django_database_constraints', ])
-        if failures: #pragma no cover
-            sys.exit(failures)
-    run_tests()
+    settings.configure(
+        DEBUG=True,
+        INSTALLED_APPS = [
+            'django_database_constraints',
+        ],
+        DATABASES = {
+            'default': _DATABASES[db],
+        },
+        MIDDLEWARE_CLASSES = [],
+    )
+    django.setup()
+
+    from django.test.runner import DiscoverRunner
+    test_runner = DiscoverRunner(verbosity=1, failfast=False)
+    failures = test_runner.run_tests(['django_database_constraints', ])
+    if failures: #pragma no cover
+        sys.exit(failures)
 
 
 if len(sys.argv) == 1: #pragma no cover
-    # we can't call run_against() multiple times and have it actually work
-    # (possibly only since Django 1.6) for reasons I don't have time to
-    # track down now (it's ignoring @override_settings on subsequent calls)
+    # we can't use @override_settings to change DATABASES, so do this in
+    # subprocesses instead
     failures = 0
-    for db in DATABASES.keys():
+    for db in _DATABASES.keys():
         args = [ sys.executable, sys.argv[0], db ]
         rc = subprocess.call(args)
         failures += rc

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ except ImportError:
     from distutils.core import setup
 
 PACKAGE = 'django_database_constraints'
-VERSION = '0.2'
+VERSION = '0.3'
 
 setup(
     name=PACKAGE, version=VERSION,
@@ -17,7 +17,7 @@ setup(
     author='James Aylett',
     author_email='james@tartarus.org',
     install_requires=[
-        'Django>=1.6.0',
+        'Django>=1.7.7',
     ],
     url = 'https://github.com/jaylett/django-database-constraints',
     classifiers = [


### PR DESCRIPTION
1. Use `form.add_error()`
2. Change test runner to set up Django in the 1.7+ way.
3. Drop use of @override_settings to change database since we don't actually need it and it emits warnings now.

Tested in postgresql, not yet on mysql.
